### PR TITLE
Add one-time-password for authentication

### DIFF
--- a/scripts/otp.js
+++ b/scripts/otp.js
@@ -1,0 +1,43 @@
+// Description:
+//   one time password for authentication
+//   it is tested on slack and heroku
+// Commands:
+//   hubot otp - get otp
+
+var timeout = parseInt(process.env.HUBOT_OTP_TIMEOUT) || 30;
+var length = parseInt(process.env.HUBOT_OTP_LENGTH) || 6;
+
+module.exports = function(robot){
+  robot.router.post("/hubot/otp/:name", function(req, res){
+    var token = req.body.token;
+    var name = req.params.name;
+
+    if (robot.brain.get(name + ".otp") == token){
+      res.status(200).jsonp({});
+      robot.brain.set(name + ".otp", null);
+    } else {
+      res.status(401).jsonp({});
+    }
+  });
+
+  robot.respond(/otp/i, otp);
+  function otp(res){
+    var token = generateToken();
+    var name = res.envelope.user.name;
+    robot.messageRoom(name, "Your token is <" + token + ">. It will be invalid in " + timeout + " seconds.");
+    robot.brain.set(name + ".otp", token);
+
+    setTimeout(function(){
+      robot.brain.set(name+".otp", null);
+    }, timeout * 1000);
+  }
+
+  function generateToken(){
+    var token = Math.floor(Math.random() * 1000000) + "";
+    while(token.length < length) {
+      token = "0" + token;
+    }
+    return token;
+  }
+}
+


### PR DESCRIPTION
When user input `zerobot otp` command, zerobot return token on private message. And 3rd party application or other application can use those token as a one-time-password. Tokens are invalid when succesefully authenticated or timeout that configure by shell envirment variable. Tokens are checked by call HTTP API on zerobot. HTTP url depend on Heroku url, but it will be `http://zerobot.herokuapp.com/hubot/otp/<id>`. If token is valid, returning status code is 200. If token is invalid, returning status code is 401. 

You can test this script by follow step. 
1. type `zerobot otp` at slack.
2. zerobot reply token in private message.
3. `curl -v -X POST http://zerobot.herokuapp.com/hubot/otp/<id> -d token=<token>` at your terminal.
4. If status code is 200, It is valid. If it is not, invalid.
